### PR TITLE
Fix link to OrientDB installation instructions

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -165,7 +165,7 @@ sovrin
 ```
 python -m sovrin_client.test
 ```
-Note. The tests create Sovrin nodes (dont worry, all nodes are created in the same process) which require OrientDB to be running. You can install OrientDB from [here](https://github.com/evernym/sovrin-common/blob/master/orientdb_installation.md).
+Note. The tests create Sovrin nodes (dont worry, all nodes are created in the same process) which require OrientDB to be running. You can install OrientDB from [here](https://github.com/sovrin-foundation/sovrin-common/blob/master/orientdb_installation.md).
 
 A Sovrin client can be configured to use flat files or OrientDB for persistence. To use files instead of OrientDB you need to add 2 entries 
 in your configuration located at `~/.sovrin/sovrin_config.py`.


### PR DESCRIPTION
The link is currently pointing at an invalid URL: `https://github.com/evernym/sovrin-common/blob/master/orientdb_installation.md`
The `evernym` part must be replaced by `sovrin-foundation` for it to work.