### PR TITLE
set crate-type to dylib

### DIFF
--- a/sovrin_client/client/lib/Cargo.toml
+++ b/sovrin_client/client/lib/Cargo.toml
@@ -3,6 +3,10 @@ name = "sovclient"
 version = "0.1.0"
 authors = ["Daniel Hardman <daniel.hardman@gmail.com>"]
 
+[lib]
+name = "sovclient"
+crate-type = ["dylib"]
+
 [dependencies]
 libc = "0.2.0"
 


### PR DESCRIPTION
i think this is required to be able to produce a standard C-callable dynamic library as opposed to a Rust-specific "rlib" file