### PR TITLE
Fixed: Observer exception is shown on CLI

### DIFF
--- a/sovrin_client/client/client.py
+++ b/sovrin_client/client/client.py
@@ -114,6 +114,7 @@ class Client(PlenumClient):
             for name in self._observers:
                 try:
                     self._observers[name](name, reqId, frm, result, numReplies)
+                    raise RuntimeError
                 except Exception as ex:
                     # TODO: All errors should not be shown on CLI, or maybe we
                     # show errors with different color according to the
@@ -121,7 +122,7 @@ class Client(PlenumClient):
                     # a malformed message should not result in an error message
                     # being shown on the cli since the clients would anyway
                     # collect enough replies from other nodes.
-                    logger.error("Observer threw an exception", exc_info=ex)
+                    logger.debug("Observer threw an exception", exc_info=ex)
             if isinstance(self.reqRepStore, ClientReqRepStoreOrientDB):
                 self.reqRepStore.setConsensus(identifier, reqId)
             if result[TXN_TYPE] == NYM:

--- a/sovrin_client/client/client.py
+++ b/sovrin_client/client/client.py
@@ -114,7 +114,6 @@ class Client(PlenumClient):
             for name in self._observers:
                 try:
                     self._observers[name](name, reqId, frm, result, numReplies)
-                    raise RuntimeError
                 except Exception as ex:
                     # TODO: All errors should not be shown on CLI, or maybe we
                     # show errors with different color according to the


### PR DESCRIPTION
Observer exception is not logged in cli.log instead of being shown on CLI