### PR TITLE
Add pytest to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ setup(
         '': ['*.txt', '*.md', '*.rst', '*.json', '*.conf', '*.html',
              '*.css', '*.ico', '*.png', 'LICENSE', 'LEGAL', '*.sovrin']},
     include_package_data=True,
-    install_requires=['sovrin-common', 'anoncreds'],
+    install_requires=['sovrin-common', 'anoncreds', 'pytest'],
     setup_requires=['pytest-runner'],
     tests_require=['pytest', 'sovrin-node'],
     scripts=['scripts/sovrin', 'scripts/change_node_ha',


### PR DESCRIPTION
pytest is required for passing though getting started tutorial - agents cannot be started without it