### PR TITLE
Add missing test for attr with no dest 

### DIFF
--- a/sovrin_client/test/test_nym_attrib.py
+++ b/sovrin_client/test/test_nym_attrib.py
@@ -460,3 +460,14 @@ def testUserAddAttrsForHerSelf(nodeSet, looper, userClientA, userWalletA,
                        dest=userIdA,
                        ledgerStore=LedgerStore.RAW)
     addAttributeAndCheck(looper, userClientA, userWalletA, attrib)
+
+
+def testAttrWithNoDestAdded(nodeSet, looper, userClientA, userWalletA,
+                               userIdA, attributeData):
+    attr1 = json.dumps({'age': 24})
+    attrib = Attribute(name='test4 attribute',
+                       origin=userIdA,
+                       value=attr1,
+                       dest=None,
+                       ledgerStore=LedgerStore.RAW)
+    addAttributeAndCheck(looper, userClientA, userWalletA, attrib)


### PR DESCRIPTION
There is missing test for case when attrib transaction has no explicit dest (in this case senders identifier used instead)