### PR TITLE
Fix attribute error on getLink function

### DIFF
--- a/sovrin_client/client/wallet/wallet.py
+++ b/sovrin_client/client/wallet/wallet.py
@@ -178,7 +178,7 @@ class Wallet(PWallet, TrustAnchoring):
         l = self._links.get(name)
         if not l and required:
             logger.debug("Wallet has links {}".format(self._links))
-            raise LinkNotFound(l.name)
+            raise LinkNotFound(name)
         return l
 
     def addLastKnownSeqs(self, identifier, seqNo):


### PR DESCRIPTION
if l is None then l.name will throw an AttributeError, so the proper LinkNotFound error is never thrown.