### PR TITLE
Test agent endpoint pubkey

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=['sovrin-common-dev==0.2.52', 'anoncreds-dev==0.3.8'],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'sovrin-node-dev==0.3.85'],
+    tests_require=['pytest', 'sovrin-node-dev==0.3.87'],
     scripts=['scripts/sovrin', 'scripts/change_node_ha',
              'scripts/add_new_node', 'scripts/reset_client'],
     cmdclass={

--- a/sovrin_client/test/cli/test_accept_invitation_base58_as_pubkey.py
+++ b/sovrin_client/test/cli/test_accept_invitation_base58_as_pubkey.py
@@ -1,0 +1,35 @@
+import json
+
+import pytest
+
+from plenum.common.constants import PUBKEY
+
+# noinspection PyUnresolvedReferences
+from sovrin_client.test.cli.conftest \
+    import faberMap as faberMapWithoutEndpointPubkey
+
+# noinspection PyUnresolvedReferences
+from sovrin_client.test.cli.test_tutorial import aliceAcceptedFaberInvitation, \
+    aliceCli, preRequisite, faberWithEndpointAdded, acmeWithEndpointAdded, \
+    thriftWithEndpointAdded, walletCreatedForTestEnv, \
+    faberInviteSyncedWithEndpoint, faberInviteSyncedWithoutEndpoint, \
+    faberInviteLoadedByAlice, acceptInvitation
+
+from sovrin_common.constants import ENDPOINT
+
+
+@pytest.fixture(scope="module")
+def faberMap(faberMapWithoutEndpointPubkey):
+    map = faberMapWithoutEndpointPubkey
+    endpointAttr = json.loads(map["endpointAttr"])
+    base58Key = '5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z'
+    endpointAttr[ENDPOINT][PUBKEY] = base58Key
+    map["endpointAttr"] = json.dumps(endpointAttr)
+    return map
+
+
+def testInvitationAcceptedIfAgentWasAddedUsingBase58AsPubkey(
+        be, do, aliceCli, faberMap, preRequisite,
+        syncedInviteAcceptedWithClaimsOut, faberInviteSyncedWithEndpoint):
+    acceptInvitation(be, do, aliceCli, faberMap,
+                     syncedInviteAcceptedWithClaimsOut)

--- a/sovrin_client/test/cli/test_accept_invitation_base58_as_pubkey.py
+++ b/sovrin_client/test/cli/test_accept_invitation_base58_as_pubkey.py
@@ -20,12 +20,12 @@ from sovrin_common.constants import ENDPOINT
 
 @pytest.fixture(scope="module")
 def faberMap(faberMapWithoutEndpointPubkey):
-    map = faberMapWithoutEndpointPubkey
-    endpointAttr = json.loads(map["endpointAttr"])
+    fbrMap = faberMapWithoutEndpointPubkey
+    endpointAttr = json.loads(fbrMap["endpointAttr"])
     base58Key = '5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z'
     endpointAttr[ENDPOINT][PUBKEY] = base58Key
-    map["endpointAttr"] = json.dumps(endpointAttr)
-    return map
+    fbrMap["endpointAttr"] = json.dumps(endpointAttr)
+    return fbrMap
 
 
 def testInvitationAcceptedIfAgentWasAddedUsingBase58AsPubkey(

--- a/sovrin_client/test/cli/test_accept_invitation_hex_as_pubkey.py
+++ b/sovrin_client/test/cli/test_accept_invitation_hex_as_pubkey.py
@@ -1,0 +1,39 @@
+import json
+
+import pytest
+
+from plenum.common.constants import PUBKEY
+from plenum.common.exceptions import BlowUp
+from plenum.common.util import cryptonymToHex
+
+# noinspection PyUnresolvedReferences
+from sovrin_client.test.cli.conftest \
+    import faberMap as faberMapWithoutEndpointPubkey
+
+# noinspection PyUnresolvedReferences
+from sovrin_client.test.cli.test_tutorial import aliceAcceptedFaberInvitation, \
+    aliceCli, preRequisite, faberWithEndpointAdded, acmeWithEndpointAdded, \
+    thriftWithEndpointAdded, walletCreatedForTestEnv, \
+    faberInviteSyncedWithEndpoint, faberInviteSyncedWithoutEndpoint, \
+    faberInviteLoadedByAlice, acceptInvitation
+
+from sovrin_common.constants import ENDPOINT
+
+
+@pytest.fixture(scope="module")
+def faberMap(faberMapWithoutEndpointPubkey):
+    map = faberMapWithoutEndpointPubkey
+    endpointAttr = json.loads(map["endpointAttr"])
+    base58Key = '5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z'
+    hexKey = cryptonymToHex(base58Key).decode()
+    endpointAttr[ENDPOINT][PUBKEY] = hexKey
+    map["endpointAttr"] = json.dumps(endpointAttr)
+    return map
+
+
+def testInvitationNotAcceptedIfAgentWasAddedUsingHexAsPubkey(
+        be, do, aliceCli, faberMap, preRequisite,
+        syncedInviteAcceptedWithClaimsOut, faberInviteSyncedWithEndpoint):
+    with pytest.raises(BlowUp):
+        acceptInvitation(be, do, aliceCli, faberMap,
+                         syncedInviteAcceptedWithClaimsOut)

--- a/sovrin_client/test/cli/test_accept_invitation_hex_as_pubkey.py
+++ b/sovrin_client/test/cli/test_accept_invitation_hex_as_pubkey.py
@@ -22,13 +22,13 @@ from sovrin_common.constants import ENDPOINT
 
 @pytest.fixture(scope="module")
 def faberMap(faberMapWithoutEndpointPubkey):
-    map = faberMapWithoutEndpointPubkey
-    endpointAttr = json.loads(map["endpointAttr"])
+    fbrMap = faberMapWithoutEndpointPubkey
+    endpointAttr = json.loads(fbrMap["endpointAttr"])
     base58Key = '5hmMA64DDQz5NzGJNVtRzNwpkZxktNQds21q3Wxxa62z'
     hexKey = cryptonymToHex(base58Key).decode()
     endpointAttr[ENDPOINT][PUBKEY] = hexKey
-    map["endpointAttr"] = json.dumps(endpointAttr)
-    return map
+    fbrMap["endpointAttr"] = json.dumps(endpointAttr)
+    return fbrMap
 
 
 def testInvitationNotAcceptedIfAgentWasAddedUsingHexAsPubkey(


### PR DESCRIPTION
Added tests that check possibility to accept an invitation for the cases when the agent was added using:
- base58 key as the pubkey (positive test);
- hex key as the pubkey (negative test).