### PR TITLE
UPDATE_paths Update the correct path to the correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Indy Client    
+mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm# Indy Client    
 
 [![Build Status](https://jenkins.evernym.com/buildStatus/icon?job=Sovrin%20Client/master)](https://jenkins.evernym.com/job/Sovrin%20Client/job/master/)    
 
@@ -13,9 +13,8 @@ understand how Indy works, starting there may be better.
 
 All bugs, backlog, and stories for Indy (except the SDK) are managed in [Hyperledger's Jira](https://jira.hyperledger.org); use project name INDY.
 
-Developers may want to explore Sovrin's [Getting Started Guide](https://github.com/sovrin-foundation/sovrin-client/blob/master/getting-started.md) to learn about how Indy works. (Sovrin is the public, open ecosystem
+Developers may want to explore Sovrin's [Getting Started Guide](https://github.com/hyperledger/indy-node/blob/master/getting-started.md) to learn about how Indy works. (Sovrin is the public, open ecosystem
 built on top of Indy technology; for more info, see [https://sovrin.org].)
 
 Have a look at [Setup Instructions](https://github.com/sovrin-foundation/sovrin-client/blob/master/setup.md)
 to understand how to work with the code. Note that setup instructions are still changing hour-by-hour as we identify install preconditions.
-

--- a/cluster-simulation.md
+++ b/cluster-simulation.md
@@ -1,5 +1,5 @@
 # Running a Simulation of a Sovrin Cluster and Agents
-One way to run through the [Sovrin Getting Started Guide](getting-started.md) is to set up a simulation of a Sovrin Validator Cluster.  This simulation resides in a single process on a single PC, but it sets up multiple asynchronous call-backs, one for each node being simulated.  These call-backs are handled sequentially in an event loop.  This gives the approximate performance of nultiple Sovrin Validator, Agent and CLI client nodes, but all running within a single process.  These instructions will configure the simulation, leaving you at the end with a CLI command-line prompt that you can use to complete the Getting Started Guide.
+One way to run through the [Sovrin Getting Started Guide](https://github.com/hyperledger/indy-node/blob/stable/getting-started.md) is to set up a simulation of a Sovrin Validator Cluster.  This simulation resides in a single process on a single PC, but it sets up multiple asynchronous call-backs, one for each node being simulated.  These call-backs are handled sequentially in an event loop.  This gives the approximate performance of nultiple Sovrin Validator, Agent and CLI client nodes, but all running within a single process.  These instructions will configure the simulation, leaving you at the end with a CLI command-line prompt that you can use to complete the Getting Started Guide.
 
 ## Install the Sovrin Client Software
 
@@ -42,7 +42,7 @@ Type this command:
 
 This command will start up a local pool of validator "nodes". This can take a few mintues and will produce a lot of console
 output. This output contains the initial communication between 4 nodes. This output can be ignored for this exercise.
- 
+
 After starting up the local sovrin pool, three agents will be launched in virtual "nodes". During this this exercise we will be interacting
 with three agents, Faber Collage, Acme Corp and Thrift Bank. Again, launching these agents can take some time and a lot of
 output.
@@ -52,6 +52,6 @@ After these tasks are complete, you should see an interactive prompt, like this:
 ```
 Sovrin - CLI version 1.17(c) 2016 Evernym, Inc.
 Type 'help' for more information.
-sovrin> 
+sovrin>
 ```
 You can now proceed with the Getting Started Guide, using this Sovrin client prompt.

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,5 +1,5 @@
 # NOTE: This version of the "Getting Started Guide" has been deprecated.
-### The correct version is located here: [Getting Started Guide](https://github.com/hyperledger/indy-node/blob/master/getting-started.md)
+### The correct version is located here: [Getting Started Guide](https://github.com/hyperledger/indy-node/blob/stable/getting-started.md)
 
 # Getting Started with Sovrin
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -1,3 +1,6 @@
+# NOTE: This version of the "Getting Started Guide" has been deprecated.
+### The correct version is located here: [Getting Started Guide](https://github.com/hyperledger/indy-node/blob/master/getting-started.md)
+
 # Getting Started with Sovrin
 
 ## A Developer Guide from the Sovrin Foundation


### PR DESCRIPTION
This updates the correct path in the README file with the correct
location of the correct version of the Getting Started Guide. It updates
the Getting Started Guide located here with a note indicating that
this particular version has been deprecated and points to the path of the
correct one.